### PR TITLE
ci: add dependabot, automerge, pre-release cleanup workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @OctopusDeploy/team-build-foundations

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
+
 updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,7 @@
+# Background
+
+<!-- Why does this PR exist? -->
+
+# Results
+
+<!-- Describe the result of the change -->

--- a/.github/workflows/cleanup-prereleases.yml
+++ b/.github/workflows/cleanup-prereleases.yml
@@ -1,0 +1,75 @@
+name: "Clean up old pre-releases"
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      days_to_keep:
+        description: 'Delete "pre-release" releases older (days)'
+        required: false
+        default: '30'
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old pre-releases
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const daysToKeep = parseInt('${{ github.event.inputs.days_to_keep || 30 }}');
+            const cutoffDate = new Date();
+            cutoffDate.setDate(cutoffDate.getDate() - daysToKeep);
+
+            // Get all releases (with pagination)
+            const allReleases = [];
+            let page = 1;
+            let releases;
+
+            do {
+              releases = await github.rest.repos.listReleases({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+                page: page
+              });
+              allReleases.push(...releases.data);
+              page++;
+            } while (releases.data.length === 100);
+
+            // Filter for pre-releases older than the cutoff date
+            const prereleases = allReleases.filter(release => release.prerelease);
+            const toDelete = prereleases.filter(release => new Date(release.created_at) < cutoffDate);
+
+            console.log(`Found ${prereleases.length} pre-releases`);
+            console.log(`Cutoff date: ${cutoffDate.toISOString()}`);
+            console.log(`Deleting pre-releases older than ${daysToKeep} days`);
+
+            if (toDelete.length === 0) {
+              console.log('No pre-releases to delete');
+              return;
+            }
+
+            console.log(`Deleting ${toDelete.length} old pre-releases:`);
+
+            for (const release of toDelete) {
+              console.log(`Deleting pre-release: ${release.name || release.tag_name} (${release.created_at})`);
+
+              try {
+                await github.rest.repos.deleteRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: release.id
+                });
+                console.log(`Deleted release ${release.tag_name}`);
+              } catch (error) {
+                console.error(`Failed to delete release ${release.tag_name}:`, error.message);
+              }
+            }

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,23 @@
+name: "Dependabot Approve and Auto Merge"
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+env:
+  PR_URL: ${{github.event.pull_request.html_url}}
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ (github.actor == 'dependabot[bot]') && (contains(github.head_ref, 'dependabot')) }}
+    steps:
+      - name: Approve a dependabot created PR
+        run: gh pr review --approve "$PR_URL"
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
# Background

Adds GitHub Actions CI infrastructure matching the pattern used in [teamcity-reportportal-plugin](https://github.com/OctopusDeploy/teamcity-reportportal-plugin).

# Results

- `.github/dependabot.yml` — daily Maven dependency updates, max 1 open PR at a time
- `.github/CODEOWNERS` — `@OctopusDeploy/team-build-foundations`
- `.github/pull-request-template.md` — standard Background/Results template
- `.github/workflows/dependabot-automerge.yml` — auto-approves and squash-merges Dependabot PRs targeting `main`
- `.github/workflows/cleanup-prereleases.yml` — daily cleanup of pre-releases older than 30 days